### PR TITLE
Add HSM CIDR to generated metadata secret

### DIFF
--- a/pkg/controller/metadata/metadata_controller.go
+++ b/pkg/controller/metadata/metadata_controller.go
@@ -205,10 +205,11 @@ func generateMetadataSecret(instance *verifyv1beta1.Metadata, metadataCreds HSMC
 			"samlSigningTruststorePassword":     []byte(samlSigningTruststorePassword),
 			"samlSigningKeyType":                []byte(cloudHSMKeyType),
 			"samlSigningKeyLabel":               []byte(samlSigningKeyLabel),
-			"hsmUser":                           []byte(metadataCreds.User),       // <-| TODO: these should be namespaceCreds
-			"hsmPassword":                       []byte(metadataCreds.Password),   // <-|
-			"hsmIP":                             []byte(metadataCreds.IP),         // <-|
-			"hsmCustomerCA.crt":                 []byte(metadataCreds.CustomerCA), // <-|
+			"hsmUser":                           []byte(metadataCreds.User),                     // <-| TODO: these should be namespaceCreds
+			"hsmPassword":                       []byte(metadataCreds.Password),                 // <-|
+			"hsmIP":                             []byte(metadataCreds.IP),                       // <-|
+			"hsmCIDR":                           []byte(fmt.Sprintf("%s/32", metadataCreds.IP)), // <-|
+			"hsmCustomerCA.crt":                 []byte(metadataCreds.CustomerCA),               // <-|
 			// "samlEncryptionCert":               samlEncyptionCert,
 			// "samlEncryptionCertBase64":         samlEncyptionCertBase64,
 			// "samlEncryptionTruststoreBase64":   samlEncryptionTruststoreBase64,


### PR DESCRIPTION
This is useful for adding things such as `NetworkPolicies` which require
a CIDR rather than just an IP.