### PR TITLE
Revert "Add HSM CIDR to generated metadata secret"

### DIFF
--- a/pkg/controller/metadata/metadata_controller.go
+++ b/pkg/controller/metadata/metadata_controller.go
@@ -175,11 +175,10 @@ func (r *ReconcileMetadata) generateMetadataSecretData(instance *verifyv1beta1.M
 		"samlSigningTruststorePassword":     []byte(samlSigningTruststorePassword),
 		"samlSigningKeyType":                []byte(cloudHSMKeyType),
 		"samlSigningKeyLabel":               []byte(samlSigningKeyLabel),
-		"hsmUser":                           []byte(metadataCreds.User),                     // <-| TODO: these should be namespaceCreds
-		"hsmPassword":                       []byte(metadataCreds.Password),                 // <-|
-		"hsmIP":                             []byte(metadataCreds.IP),                       // <-|
-		"hsmCIDR":                           []byte(fmt.Sprintf("%s/32", metadataCreds.IP)), // <-|
-		"hsmCustomerCA.crt":                 []byte(metadataCreds.CustomerCA),               // <-|
+		"hsmUser":                           []byte(metadataCreds.User),       // <-| TODO: these should be namespaceCreds
+		"hsmPassword":                       []byte(metadataCreds.Password),   // <-|
+		"hsmIP":                             []byte(metadataCreds.IP),         // <-|
+		"hsmCustomerCA.crt":                 []byte(metadataCreds.CustomerCA), // <-|
 		// "samlEncryptionCert":               samlEncyptionCert,
 		// "samlEncryptionCertBase64":         samlEncyptionCertBase64,
 		// "samlEncryptionTruststoreBase64":   samlEncryptionTruststoreBase64,


### PR DESCRIPTION
This reverts commit dd8a92da1d5c66d6718e3e49f2737257cc4ab526.

This does not actually help with what I wanted to do. Even if we expose
a CIDR you can't reference a `ConfigMap`/`Secret` from a
`NetworkPolicy`.