### PR TITLE
[DO NOT MERGE] Generate a CSR from CloudHSM keypair

### DIFF
--- a/cloudhsmtool/build.gradle
+++ b/cloudhsmtool/build.gradle
@@ -23,7 +23,8 @@ dependencies {
     'com.github.spullara.mustache.java:compiler:0.9.6',
     'org.yaml:snakeyaml:1.24-SNAPSHOT',
     'org.apache.logging.log4j:log4j-api:2.8',
-    'org.apache.logging.log4j:log4j-core:2.8'
+    'org.apache.logging.log4j:log4j-core:2.8', 
+    'com.fasterxml.jackson.core:jackson-databind:2.9.9'
 
     if (project.hasProperty('cloudhsm')) {
       implementation name: 'cloudhsm-2.0.0'

--- a/cloudhsmtool/src/main/java/uk/gov/ida/cloudhsmtool/GenRSA.java
+++ b/cloudhsmtool/src/main/java/uk/gov/ida/cloudhsmtool/GenRSA.java
@@ -83,7 +83,7 @@ public class GenRSA implements Callable<Void> {
 			Map<String, String> errorMap = Map.of(
 					"error", e.getMessage(),
 					"stack", sw.toString());
-			System.out.println(new ObjectMapper().writeValueAsString(errorMap));
+			System.err.println(new ObjectMapper().writeValueAsString(errorMap));
 			System.exit(1);
 		}
 

--- a/pkg/controller/metadata/metadata_controller_test.go
+++ b/pkg/controller/metadata/metadata_controller_test.go
@@ -55,7 +55,7 @@ func TestReconcile(t *testing.T) {
 	// Setup fake hsm client
 	var cloudHSMToolResponse = hsm.CloudHSMToolResponse{"<signed>FAKE-SIGNED-META</signed>", "a CSR"}
 	hsmClient := &hsmfakes.FakeClient{}
-	hsmClient.FindOrCreateRSAKeyPairReturns(cloudHSMToolResponse, nil)
+	hsmClient.FindOrCreateRSAKeyPairReturns(metadataSigningCert, nil)
 	hsmClient.GenerateAndSignMetadataReturns(cloudHSMToolResponse, nil)
 
 	// Setup the Manager and Controller.

--- a/pkg/hsm/client.go
+++ b/pkg/hsm/client.go
@@ -11,8 +11,13 @@ type Credentials struct {
 	CustomerCA string
 }
 
+type CloudHSMToolResponse struct {
+	Certificate 				string `json:"certificate"`
+	CertificateSigningRequest	string `json:"csr"`
+}
+
 type Client interface {
-	CreateRSAKeyPair(label string, hsmCreds Credentials) (publicCert []byte, err error)
-	FindOrCreateRSAKeyPair(label string, hsmCreds Credentials) (signingCert []byte, err error)
+	CreateRSAKeyPair(label string, hsmCreds Credentials) (response hsm.CloudHSMToolResponse, err error)
+	FindOrCreateRSAKeyPair(label string, hsmCreds Credentials) (response hsm.CloudHSMToolResponse, err error)
 	GenerateAndSignMetadata(metadataSigningCert []byte, metadataSigningKeyLabel string, spec verifyv1beta1.MetadataSpec, hsmCreds Credentials) (signedMetadata []byte, err error)
 }


### PR DESCRIPTION
Generate a CSR based on a CloudHSM keypair.
A certificate authority will sign the CSR to produce a certificate.
This certificate will be used to create our metadata digital signature.