### PR TITLE
adds root CertificateRequests for prod/test CA generation

### DIFF
--- a/chart/templates/cert-request-production.yaml
+++ b/chart/templates/cert-request-production.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: verify.gov.uk/v1beta1
+kind: CertificateRequest
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: verify-root-ca-production
+  namespace: {{ .Release.Namespace }}
+spec:
+  countryCode: GB
+  commonName: Verify Root CA
+  expiryMonths: 120
+  organization: Cabinet Office
+  organizationUnit: GDS
+  location: London
+  CACert: true

--- a/chart/templates/cert-request-test.yaml
+++ b/chart/templates/cert-request-test.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: verify.gov.uk/v1beta1
+kind: CertificateRequest
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: verify-root-ca-test
+  namespace: {{ .Release.Namespace }}
+spec:
+  countryCode: GB
+  commonName: Verify Test Root CA
+  expiryMonths: 120
+  organization: Cabinet Office
+  organizationUnit: GDS
+  location: London
+  CACert: true


### PR DESCRIPTION
This will add two CertificateRequests to the VMC to generate Root CA Secrets for "verify-root-ca-production" (that will be used for production deployments) and "verify-root-ca-test" (used for non-production deployments)