### PR TITLE
adds CA chain value to generated metadata secret

### DIFF
--- a/pkg/controller/certificaterequest/certificaterequest_controller.go
+++ b/pkg/controller/certificaterequest/certificaterequest_controller.go
@@ -47,11 +47,11 @@ var log = logf.Log.WithName("controller")
 // Add creates a new CertificateRequest Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, hsmClient hsm.Client) error {
-	return add(mgr, newReconciler(mgr, hsmClient))
+	return AddReconciler(mgr, NewReconciler(mgr, hsmClient))
 }
 
-// newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, hsmClient hsm.Client) reconcile.Reconciler {
+// NewReconciler returns a new reconcile.Reconciler
+func NewReconciler(mgr manager.Manager, hsmClient hsm.Client) reconcile.Reconciler {
 	return &ReconcileCertificateRequest{
 		Client: mgr.GetClient(),
 		scheme: mgr.GetScheme(),
@@ -59,8 +59,8 @@ func newReconciler(mgr manager.Manager, hsmClient hsm.Client) reconcile.Reconcil
 	}
 }
 
-// add adds a new Controller to mgr with r as the reconcile.Reconciler
-func add(mgr manager.Manager, r reconcile.Reconciler) error {
+// AddReconciler adds a new Controller to mgr with r as the reconcile.Reconciler
+func AddReconciler(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
 	c, err := controller.New("certificaterequest-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {

--- a/pkg/controller/certificaterequest/certificaterequest_controller_test.go
+++ b/pkg/controller/certificaterequest/certificaterequest_controller_test.go
@@ -64,8 +64,8 @@ func TestReconcileRootCA(t *testing.T) {
 	mgr, err := manager.New(cfg, manager.Options{})
 	g.Expect(err).NotTo(HaveOccurred())
 	c := mgr.GetClient()
-	recFn, reconcileCallCount := SetupTestReconcile(newReconciler(mgr, hsmClient), t)
-	g.Expect(add(mgr, recFn)).NotTo(HaveOccurred())
+	recFn, reconcileCallCount := SetupTestReconcile(NewReconciler(mgr, hsmClient), t)
+	g.Expect(AddReconciler(mgr, recFn)).NotTo(HaveOccurred())
 	stopMgr, mgrStopped := StartTestManager(mgr, g)
 	defer func() {
 		close(stopMgr)
@@ -182,8 +182,8 @@ func TestReconcileIntermediateCA(t *testing.T) {
 	mgr, err := manager.New(cfg, manager.Options{})
 	g.Expect(err).NotTo(HaveOccurred())
 	c := mgr.GetClient()
-	recFn, reconcileCallCount := SetupTestReconcile(newReconciler(mgr, hsmClient), t)
-	g.Expect(add(mgr, recFn)).NotTo(HaveOccurred())
+	recFn, reconcileCallCount := SetupTestReconcile(NewReconciler(mgr, hsmClient), t)
+	g.Expect(AddReconciler(mgr, recFn)).NotTo(HaveOccurred())
 	stopMgr, mgrStopped := StartTestManager(mgr, g)
 	defer func() {
 		close(stopMgr)


### PR DESCRIPTION
Adds the following values to the generated metdata Secret:

* metadataCACerts: concat list of PEM CA certs for the metadata signing
* metadataCATruststore: truststore version of above for java-land
* metadataCATruststoreBase64: base64 version of above as that is what
  the app accepts
* metadataCATruststorePassword: password for above

Adds tests to cover some of the recent changes and the CA cert bundling