### PR TITLE
fix inconsistant use of CACert and pass to tool

### DIFF
--- a/chart/templates/verify_v1beta1_certificaterequest.yaml
+++ b/chart/templates/verify_v1beta1_certificaterequest.yaml
@@ -28,7 +28,7 @@ spec:
           type: object
         spec:
           properties:
-            caCert:
+            CACert:
               type: boolean
             certificateAuthority:
               properties:

--- a/chart/templates/verify_v1beta1_metadata.yaml
+++ b/chart/templates/verify_v1beta1_metadata.yaml
@@ -67,7 +67,7 @@ spec:
               type: string
             samlSigningCertRequest:
               properties:
-                caCert:
+                CACert:
                   type: boolean
                 certificateAuthority:
                   properties:

--- a/config/crds/verify_v1beta1_certificaterequest.yaml
+++ b/config/crds/verify_v1beta1_certificaterequest.yaml
@@ -28,7 +28,7 @@ spec:
           type: object
         spec:
           properties:
-            caCert:
+            CACert:
               type: boolean
             certificateAuthority:
               properties:

--- a/config/crds/verify_v1beta1_metadata.yaml
+++ b/config/crds/verify_v1beta1_metadata.yaml
@@ -67,7 +67,7 @@ spec:
               type: string
             samlSigningCertRequest:
               properties:
-                caCert:
+                CACert:
                   type: boolean
                 certificateAuthority:
                   properties:

--- a/pkg/apis/verify/v1beta1/certificaterequest_types.go
+++ b/pkg/apis/verify/v1beta1/certificaterequest_types.go
@@ -36,7 +36,7 @@ type CertificateRequestSpec struct {
 	Location             string                    `json:"location,omitempty"`
 	Organization         string                    `json:"organization,omitempty"`
 	OrganizationUnit     string                    `json:"organizationUnit,omitempty"`
-	CACert               bool                      `json:"caCert,omitempty"`
+	CACert               bool                      `json:"CACert,omitempty"`
 	CertificateAuthority *CertificateAuthoritySpec `json:"certificateAuthority,omitempty"`
 }
 

--- a/pkg/controller/certificaterequest/certificaterequest_controller.go
+++ b/pkg/controller/certificaterequest/certificaterequest_controller.go
@@ -130,6 +130,7 @@ func (r *ReconcileCertificateRequest) Reconcile(request reconcile.Request) (reco
 			Location:         instance.Spec.Location,
 			Organization:     instance.Spec.Organization,
 			OrganizationUnit: instance.Spec.OrganizationUnit,
+			CACert:           instance.Spec.CACert,
 		}
 
 		// the hsm fn to call


### PR DESCRIPTION
CACert was not being set on the CertRequest before being passed to
CreateChainCertificate.

Standandize on CACert over caCert since this was being used in more
places already