### PR TITLE
Mark basicContraints x509 extension as critical for CA certs

### DIFF
--- a/cloudhsmtool/src/main/java/uk/gov/ida/cloudhsmtool/CreateChainedCertificate.java
+++ b/cloudhsmtool/src/main/java/uk/gov/ida/cloudhsmtool/CreateChainedCertificate.java
@@ -72,7 +72,7 @@ public class CreateChainedCertificate extends CreateSelfSignedCertificate implem
 
         if (certAuthority) {
             certBuilder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.keyCertSign));
-            certBuilder.addExtension(Extension.basicConstraints, false, new BasicConstraints(true));
+            certBuilder.addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
         } else {
             certBuilder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.digitalSignature));
         }

--- a/cloudhsmtool/src/main/java/uk/gov/ida/cloudhsmtool/CreateSelfSignedCertificate.java
+++ b/cloudhsmtool/src/main/java/uk/gov/ida/cloudhsmtool/CreateSelfSignedCertificate.java
@@ -97,7 +97,7 @@ public class CreateSelfSignedCertificate extends HSMCli implements Callable<Void
         );
 
         certBuilder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.keyCertSign));
-        certBuilder.addExtension(Extension.basicConstraints, false, new BasicConstraints(true));
+        certBuilder.addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
 
         ContentSigner signer = new CaviumRSAContentSigner(keyPair.getPrivate(), SIGNING_ALGO_SHA256_RSA);
 


### PR DESCRIPTION
When we create a CA cert using the [cloudhsmtool](https://github.com/alphagov/verify-metadata-controller/blob/master/cloudhsmtool/README.md), the x509 Extension section shows:
```
Extensions
  basicConstraints :
    cA=true
```
According to [X509 Extension Spec](https://access.redhat.com/documentation/en-US/Red_Hat_Certificate_System/8.0/html/Admin_Guide/Standard_X.509_v3_Certificate_Extensions.html) (search for basicConstraints), this extension must be marked critical so that it looks like:

```
Extensions
  basicConstraints CRITICAL:
    cA=true
```

This PR will surface that CRITICAL keyword. 