### PR TITLE
Kustomization: Move rbac/manager resources into their own kustomizati…

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,15 +18,8 @@ namePrefix: verify-metadata-controller-
 # YAML string, with resources separated by document
 # markers ("---").
 resources:
-- ../rbac/rbac_role.yaml
-- ../rbac/rbac_role_binding.yaml
-- ../manager/manager.yaml
-  # Comment the following 3 lines if you want to disable
-  # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
-  # which protects your /metrics endpoint.
-- ../rbac/auth_proxy_service.yaml
-- ../rbac/auth_proxy_role.yaml
-- ../rbac/auth_proxy_role_binding.yaml
+- ../rbac/
+- ../manager/
 
 patches:
 - manager_image_patch.yaml

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- manager.yaml

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+- rbac_role.yaml
+- rbac_role_binding.yaml
+  # Comment the following 3 lines if you want to disable
+  # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
+  # which protects your /metrics endpoint.
+- auth_proxy_service.yaml
+- auth_proxy_role.yaml
+- auth_proxy_role_binding.yaml


### PR DESCRIPTION
…on files to avoid security problems

To deal with this error:
Error: accumulating resources: accumulating resources from '../manager/manager.yaml': security; file '/Users/alexmonk/verify-metadata-controller/config/manager/manager.yaml' is not in or below '/Users/alexmonk/verify-metadata-controller/config/default'
It seems it's fine to refer to other directories containing kustomization.yaml files with resources, just not directly to those resources.

Based on https://github.com/kubernetes-sigs/kustomize/issues/766#issuecomment-465348108