### PR TITLE
Kustomization: Don't use default namespace

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,6 +1,3 @@
-# Adds namespace to all resources.
-namespace: default
-
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: default
+  namespace: system


### PR DESCRIPTION
It seems the "default" namespace is replaced with null by Kustomize for some
reason.
This seems to allow the kubectl to be applied, though may not work correctly?