### PR TITLE
BAU Update logging to test release process

### DIFF
--- a/pkg/controller/metadata/metadata_controller.go
+++ b/pkg/controller/metadata/metadata_controller.go
@@ -366,6 +366,11 @@ func (r *ReconcileMetadata) Reconcile(request reconcile.Request) (reconcile.Resu
 		return reconcile.Result{}, err
 	}
 	currentVersion := fmt.Sprintf("%d", currentVersionInt)
+	log.Info("Hash of metadata values",
+		"namespace", instance.Namespace,
+		"hashValue", currentVersion,
+		"name", instance.Name,
+	)
 
 	// lookup certificate authority data
 	metadataSigningSecret := &corev1.Secret{}


### PR DESCRIPTION
This fairly useless piece of logging is to trigger a new release of the
VMC so we can check the release process.