### PR TITLE
Remove leaf cert from set of CA certs saved to metadata secret

### DIFF
--- a/pkg/controller/metadata/metadata_controller.go
+++ b/pkg/controller/metadata/metadata_controller.go
@@ -216,7 +216,7 @@ func (r *ReconcileMetadata) generateMetadataSecretData(instance *verifyv1beta1.M
 	if err != nil {
 		return nil, fmt.Errorf("generateMetadataSecretData: %s", err)
 	}
-	metadataCACertsConcat := bytes.Join(metadataCACerts, []byte("\n"))
+	metadataCACertsConcat := bytes.Join(metadataCACerts[1:], []byte("\n"))
 	metadataCATruststore, err := generateTruststore(metadataCACertsConcat, "ca", truststorePassword)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/metadata/metadata_controller.go
+++ b/pkg/controller/metadata/metadata_controller.go
@@ -216,7 +216,13 @@ func (r *ReconcileMetadata) generateMetadataSecretData(instance *verifyv1beta1.M
 	if err != nil {
 		return nil, fmt.Errorf("generateMetadataSecretData: %s", err)
 	}
-	metadataCACertsConcat := bytes.Join(metadataCACerts[1:], []byte("\n"))
+	var metadataCACertsConcat []byte
+	if len(metadataCACerts) > 1 {
+		metadataCACertsConcat = bytes.Join(metadataCACerts[1:], []byte("\n"))
+	} else {
+		metadataCACertsConcat = metadataCACerts[0]
+	}
+
 	metadataCATruststore, err := generateTruststore(metadataCACertsConcat, "ca", truststorePassword)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/metadata/metadata_controller_test.go
+++ b/pkg/controller/metadata/metadata_controller_test.go
@@ -230,7 +230,7 @@ func TestReconcile(t *testing.T) {
 	g.Eventually(getSecretData("hsmCustomerCA.crt")).Should(Equal(fakeCustomerCA))
 	g.Eventually(getSecretData("metadataCATruststore")).ShouldNot(Equal([]byte{}))
 	g.Eventually(getSecretData("metadataCATruststoreBase64")).ShouldNot(Equal([]byte{}))
-	g.Eventually(getSecretData("metadataCACerts")).Should(Equal(bytes.Join([][]byte{fakeRootCert, fakeIntCert, fakeMetadataCert}, []byte("\n"))))
+	g.Eventually(getSecretData("metadataCACerts")).Should(Equal(bytes.Join([][]byte{fakeRootCert, fakeIntCert}, []byte("\n"))))
 	g.Eventually(getSecretData("publishingPath")).Should(Equal([]byte("metadata.xml")))
 	// TODO: add the rest of the Secret fields here...
 
@@ -428,7 +428,7 @@ func TestReconcileMetadataWithProvidedCerts(t *testing.T) {
 	g.Eventually(getSecretData("samlEncryptionCert")).Should(Equal(formatCertString(string(suppliedEncryptionCert))))
 	g.Eventually(getSecretData("metadataCATruststore")).ShouldNot(Equal([]byte{}))
 	g.Eventually(getSecretData("metadataCATruststoreBase64")).ShouldNot(Equal([]byte{}))
-	g.Eventually(getSecretData("metadataCACerts")).Should(Equal(bytes.Join([][]byte{fakeRootCert, fakeIntCert, fakeMetadataCert}, []byte("\n"))))
+	g.Eventually(getSecretData("metadataCACerts")).Should(Equal(bytes.Join([][]byte{fakeRootCert, fakeIntCert}, []byte("\n"))))
 	g.Eventually(getSecretData("hsmUser")).Should(BeNil())
 	g.Eventually(getSecretData("hsmPassword")).Should(BeNil())
 	g.Eventually(getSecretData("hsmIP")).Should(BeNil())


### PR DESCRIPTION
We publish our Proxy Node certificate authorities for Proxy Node metadata at:
https://test-integration-proxy-node.london.verify.govsvc.uk/ServiceMetadataSigningCertificates

Similarly, we publish Connector Node certificate authorities for Connector Node metadata at: 
https://test-integration-connector.london.verify.govsvc.uk/ConnectorMetadataSigningCertificates

These certs are derived from a secret stored in the k8s cluster - currently we store not only the CA certs, but also the "leaf" metadata signing cert in the secret. We don't need to show the leaf cert, and subsequently have to stop it showing on the urls above.

This PR removes the leaf cert saved to the secret.
Another PR will remove the filtering we have to do to stop it appearing.
