### PR TITLE
EID-1615: Store the valid until 

### DIFF
--- a/chart/templates/verify_v1beta1_metadata.yaml
+++ b/chart/templates/verify_v1beta1_metadata.yaml
@@ -65,7 +65,8 @@ spec:
                 samlSigningCertificate:
                   type: string
                 validityDays:
-                  type: string
+                  format: int64
+                  type: integer
               type: object
             enabled:
               type: boolean

--- a/config/crds/verify_v1beta1_metadata.yaml
+++ b/config/crds/verify_v1beta1_metadata.yaml
@@ -65,7 +65,8 @@ spec:
                 samlSigningCertificate:
                   type: string
                 validityDays:
-                  type: string
+                  format: int64
+                  type: integer
               type: object
             enabled:
               type: boolean

--- a/mdgen/docker/integration_tests/features/feature/launch.feature
+++ b/mdgen/docker/integration_tests/features/feature/launch.feature
@@ -14,7 +14,7 @@ Feature: The java app
     When I run the java executable with correct parameters for the proxy node
     Then I see that the application outputs a file
     And the file contains the supplied saml signing certificate: "<cert>"
-    And the file contains the supplied saml encryption certificate: "<cert>"
+    And the file does not contain a saml encryption certificate
     Examples:
       | cert                                     |
       | test-hsm-generated-saml-signing-cert.pem |

--- a/mdgen/src/main/java/uk/gov/ida/mdgen/MetadataGenerator.java
+++ b/mdgen/src/main/java/uk/gov/ida/mdgen/MetadataGenerator.java
@@ -120,8 +120,8 @@ public class MetadataGenerator implements Callable<Void> {
     @CommandLine.Option(names = "--supplied-saml-encryption-cert-file", description = "Public X509 cert for SAML encryption certificate supplied manually")
     private File manuallySuppliedSamlEncryptionCert;
 
-    @CommandLine.Option(names = "--validityDays", description = "How many days the metadata is valid for (default 30 days)")
-    private Integer validityDays = 30;
+    @CommandLine.Option(names = "--validityTimestamp", description = "Expiry timestamp for metadata using ISO8601, e.g (2015-05-24T19:30:26.624Z)")
+    private String validityTimestamp = "2015-05-24T19:30:26.624Z";
 
 
     public static void main(String[] args) throws InitializationException {
@@ -208,7 +208,7 @@ public class MetadataGenerator implements Callable<Void> {
         String xml = renderTemplate(nodeType.toString() + "_template.xml.mustache", yamlMap);
         EntityDescriptor entityDescriptor = ObjectUtils.unmarshall(new ByteArrayInputStream(xml.getBytes()), EntityDescriptor.class);
         entityDescriptor.setID(UUID.randomUUID().toString());
-        entityDescriptor.setValidUntil(DateTime.now().plusDays(validityDays));
+        entityDescriptor.setValidUntil(new DateTime(validityTimestamp));
         updateSsoDescriptors(entityDescriptor);
         sign(entityDescriptor);
         return entityDescriptor;

--- a/pkg/apis/verify/v1beta1/metadata_types.go
+++ b/pkg/apis/verify/v1beta1/metadata_types.go
@@ -35,7 +35,7 @@ type MetadataSigningSpec struct {
 	ContactEmail              string `json:"contactEmail,omitempty"`
 	SamlSigningCertificate    string `json:"samlSigningCertificate,omitempty"`
 	SamlEncryptionCertificate string `json:"samlEncryptionCertificate,omitempty"`
-	ValidityDays              string `json:"validityDays,omitempty"`
+	ValidityDays              int    `json:"validityDays,omitempty"`
 }
 
 // MetadataSpec defines the desired state of Metadata

--- a/pkg/controller/metadata/metadata_controller.go
+++ b/pkg/controller/metadata/metadata_controller.go
@@ -269,7 +269,7 @@ func (r *ReconcileMetadata) generateMetadataSecretData(instance *verifyv1beta1.M
 
 	certificateExpiry := time.Now().AddDate(0, 0, instance.Spec.Data.ValidityDays)
 
-	certificateExpiryTimestamp := certificateExpiry.Format(time.RFC1123)
+	certificateExpiryTimestamp := certificateExpiry.Format(time.RFC1123Z)
 
 	metadataRequest := hsm.GenerateMetadataRequest{
 		MetadataSigningCert:     metadataSigningCert,

--- a/pkg/controller/metadata/metadata_controller_test.go
+++ b/pkg/controller/metadata/metadata_controller_test.go
@@ -19,11 +19,12 @@ package metadata
 import (
 	"bytes"
 	"io/ioutil"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"os"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	verifyv1beta1 "github.com/alphagov/verify-metadata-controller/pkg/apis/verify/v1beta1"
 	"github.com/alphagov/verify-metadata-controller/pkg/controller/certificaterequest"
@@ -140,7 +141,7 @@ func TestReconcile(t *testing.T) {
 				ContactGivenName: "jeff",
 				ContactSurname:   "jefferson",
 				ContactEmail:     "jeff@jeff.com",
-				ValidityDays:     "30",
+				ValidityDays:     30,
 			},
 			CertificateAuthority: verifyv1beta1.CertificateAuthoritySpec{
 				SecretName: "meta",
@@ -233,6 +234,11 @@ func TestReconcile(t *testing.T) {
 	g.Eventually(getSecretData("metadataCATruststoreBase64")).ShouldNot(Equal([]byte{}))
 	g.Eventually(getSecretData("metadataCACerts")).Should(Equal(bytes.Join([][]byte{fakeRootCert, fakeIntCert, fakeMetadataCert}, []byte("\n"))))
 	g.Eventually(getSecretData("publishingPath")).Should(Equal([]byte("metadata.xml")))
+	g.Eventually(getSecretData("validityDays")).Should(Equal([]byte("30")))
+
+	byteValidUntil, _ := getSecretData("validUntil")()
+
+	g.Eventually(checkDateIsInRange(byteValidUntil)).Should(Equal(true))
 	// TODO: add the rest of the Secret fields here...
 
 	// We expect a an nginx Deployment to be created with the same name
@@ -434,6 +440,17 @@ func TestReconcileMetadataWithProvidedCerts(t *testing.T) {
 	g.Eventually(getSecretData("hsmPassword")).Should(BeNil())
 	g.Eventually(getSecretData("hsmIP")).Should(BeNil())
 	g.Eventually(getSecretData("hsmCustomerCA.crt")).Should(BeNil())
+}
+
+func checkDateIsInRange(byteStrInputDate []byte) bool {
+	timeObjInputDate, _ := time.Parse(time.RFC1123, string(byteStrInputDate))
+
+	currentTime := time.Now().AddDate(0, 0, 30)
+
+	beforeTime := currentTime.Add(-30 * time.Second)
+	afterTime := currentTime.Add(30 * time.Second)
+
+	return timeObjInputDate.After(beforeTime) && timeObjInputDate.Before(afterTime)
 }
 
 func generateCertChain(t *testing.T, ctx context.Context, c client.Client, g *GomegaWithT) (*verifyv1beta1.CertificateRequest, *verifyv1beta1.CertificateRequest, *verifyv1beta1.CertificateRequest, func(t *testing.T)) {

--- a/pkg/controller/metadata/metadata_controller_test.go
+++ b/pkg/controller/metadata/metadata_controller_test.go
@@ -443,7 +443,7 @@ func TestReconcileMetadataWithProvidedCerts(t *testing.T) {
 }
 
 func checkDateIsInRange(byteStrInputDate []byte) bool {
-	timeObjInputDate, _ := time.Parse(time.RFC1123, string(byteStrInputDate))
+	timeObjInputDate, _ := time.Parse(time.RFC1123Z, string(byteStrInputDate))
 
 	currentTime := time.Now().AddDate(0, 0, 30)
 

--- a/pkg/hsm/awscloudhsm/cloudhsm.go
+++ b/pkg/hsm/awscloudhsm/cloudhsm.go
@@ -162,7 +162,7 @@ func (c *Client) GenerateAndSignMetadata(request hsm.GenerateMetadataRequest) (s
 		"--hsm-saml-signing-key-label", request.SamlSigningKeyLabel,
 		samlSigningOption, tmpSAMLSigningCertPath,
 		"--supplied-saml-encryption-cert-file", tmpSAMLEncryptionCertPath,
-		"--validityDays", request.Data.ValidityDays,
+		"--validityTimestamp", request.Data.ValidityTimestamp,
 	)
 	cmd.Env = append(os.Environ(),
 		fmt.Sprintf("HSM_USER=%s", request.HSMCreds.User),

--- a/pkg/hsm/client.go
+++ b/pkg/hsm/client.go
@@ -20,17 +20,17 @@ type GenerateMetadataRequest struct {
 }
 
 type MetadataRequestData struct {
-	EntityID         string `yaml:"entity_id"`
-	PostURL          string `yaml:"post_url"`
-	RedirectURL      string `yaml:"redirect_url"`
-	OrgName          string `yaml:"org_name"`
-	OrgDisplayName   string `yaml:"org_display_name"`
-	OrgURL           string `yaml:"org_url"`
-	ContactCompany   string `yaml:"contact_company"`
-	ContactGivenName string `yaml:"contact_given_name"`
-	ContactSurname   string `yaml:"contact_surname"`
-	ContactEmail     string `yaml:"contact_email"`
-	ValidityDays     string `yaml:"validity_days"`
+	EntityID          string `yaml:"entity_id"`
+	PostURL           string `yaml:"post_url"`
+	RedirectURL       string `yaml:"redirect_url"`
+	OrgName           string `yaml:"org_name"`
+	OrgDisplayName    string `yaml:"org_display_name"`
+	OrgURL            string `yaml:"org_url"`
+	ContactCompany    string `yaml:"contact_company"`
+	ContactGivenName  string `yaml:"contact_given_name"`
+	ContactSurname    string `yaml:"contact_surname"`
+	ContactEmail      string `yaml:"contact_email"`
+	ValidityTimestamp string `yaml:"validity_days"`
 }
 
 type Client interface {


### PR DESCRIPTION
Change the timestamp to be RFC1123Z rather than to use days,

It also adds them to the metadata secrets.

We want todo this so we can check the certificate expirer externally so we can later regenerate the certificates when they expire.