### PR TITLE
EID-1616: Added in logic to determine if we should regenerate metadata if metadata is at least halfway through its lifecycle

### DIFF
--- a/pkg/controller/metadata/metadata_controller_test.go
+++ b/pkg/controller/metadata/metadata_controller_test.go
@@ -141,7 +141,7 @@ func TestReconcile(t *testing.T) {
 				ContactGivenName: "jeff",
 				ContactSurname:   "jefferson",
 				ContactEmail:     "jeff@jeff.com",
-				ValidityDays:     30,
+				ValidityDays:     0,
 			},
 			CertificateAuthority: verifyv1beta1.CertificateAuthoritySpec{
 				SecretName: "meta",
@@ -203,7 +203,7 @@ func TestReconcile(t *testing.T) {
 	}
 	g.Eventually(getSecretResource).Should(Succeed())
 	g.Expect(secretResource.ObjectMeta.Annotations).ShouldNot(BeNil())
-	g.Expect(secretResource.ObjectMeta.Annotations[VersionAnnotation]).ShouldNot(Equal(""))
+	g.Expect(secretResource.ObjectMeta.Annotations[versionAnnotation]).ShouldNot(Equal(""))
 
 	// We expect the Secret Data values to be generated from Metadata
 	getSecretData := func(key string) func() ([]byte, error) {
@@ -408,7 +408,7 @@ func TestReconcileMetadataWithProvidedCerts(t *testing.T) {
 	}
 	g.Eventually(getSecretResource).Should(Succeed())
 	g.Expect(secretResource.ObjectMeta.Annotations).ShouldNot(BeNil())
-	g.Expect(secretResource.ObjectMeta.Annotations[VersionAnnotation]).ShouldNot(Equal(""))
+	g.Expect(secretResource.ObjectMeta.Annotations[versionAnnotation]).ShouldNot(Equal(""))
 
 	// We expect the Secret Data values to be generated from Metadata
 	getSecretData := func(key string) func() ([]byte, error) {
@@ -557,4 +557,54 @@ func generateCertChain(t *testing.T, ctx context.Context, c client.Client, g *Go
 	}
 
 	return rootCertReq, intCertReq, metaCertReq, tearDown
+}
+
+func TestShouldRegenerate(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	const ConstantHash = "Im a constant hash"
+
+	mockSecrets := corev1.Secret{}
+	mockSecrets.ObjectMeta.Annotations = make(map[string]string)
+	mockSecrets.Data = make(map[string][]byte)
+
+	// Hashes should differ, so should be true to regenerate
+	mockSecrets.ObjectMeta.Annotations[versionAnnotation] = ""
+	g.Eventually(ShouldRegenerate(&mockSecrets, ConstantHash)).Should(BeTrue())
+
+	// Hash should now match, but there is no data for the expiration, this simulates a upgrade.
+	mockSecrets.ObjectMeta.Annotations[versionAnnotation] = ConstantHash
+	g.Eventually(ShouldRegenerate(&mockSecrets, ConstantHash)).Should(BeTrue())
+
+	// There should be a parse error.
+	mockSecrets.Data[validityDays] = []byte("30")
+	mockSecrets.Data[validUntil] = []byte("")
+	g.Eventually(ShouldRegenerate(&mockSecrets, ConstantHash)).Should(BeTrue())
+
+	// Should regenerate as time is in the past.
+	mockSecrets.Data[validUntil] = []byte(time.Now().AddDate(0, 0, -1).Format(time.RFC1123Z))
+	g.Eventually(ShouldRegenerate(&mockSecrets, ConstantHash)).Should(BeTrue())
+
+	// Should regenerate if half of the validity days.
+	mockSecrets.Data[validUntil] = []byte(time.Now().AddDate(0, 0, 15).Format(time.RFC1123Z))
+	g.Eventually(ShouldRegenerate(&mockSecrets, ConstantHash)).Should(BeTrue())
+
+	// Shouldn't regenerate if more than half of the validity days.
+	mockSecrets.Data[validUntil] = []byte(time.Now().AddDate(0, 0, 15).Add(time.Duration(time.Minute)).Format(time.RFC1123Z))
+	g.Eventually(ShouldRegenerate(&mockSecrets, ConstantHash)).Should(BeFalse())
+
+	// Shouldn't regenerate as in the future.
+	mockSecrets.Data[validUntil] = []byte(time.Now().AddDate(0, 0, 60).Format(time.RFC1123Z))
+	g.Eventually(ShouldRegenerate(&mockSecrets, ConstantHash)).Should(BeFalse())
+
+	// Should work with odd values of validityDays
+	mockSecrets.Data[validityDays] = []byte("1")
+	mockSecrets.Data[validUntil] = []byte(time.Now().Format(time.RFC1123Z))
+	g.Eventually(ShouldRegenerate(&mockSecrets, ConstantHash)).Should(BeTrue())
+
+	mockSecrets.Data[validUntil] = []byte(time.Now().Add(time.Duration(time.Hour * 12)).Format(time.RFC1123Z))
+	g.Eventually(ShouldRegenerate(&mockSecrets, ConstantHash)).Should(BeTrue())
+
+	mockSecrets.Data[validUntil] = []byte(time.Now().Add(time.Duration(time.Hour*12 + time.Minute)).Format(time.RFC1123Z))
+	g.Eventually(ShouldRegenerate(&mockSecrets, ConstantHash)).Should(BeFalse())
 }


### PR DESCRIPTION
Add logic to pick out the values saved in the metadata secrets detailing the expirey of the metadata, check it and if we are over half way through the metadatas life cycle then trigger regeneration of the metadata / certificates.