### PR TITLE
Eid 1624 schedule reconciliation of the metadata definition

### DIFF
--- a/pkg/controller/metadata/metadata_controller.go
+++ b/pkg/controller/metadata/metadata_controller.go
@@ -58,6 +58,7 @@ const (
 	validUntil         = "validUntil"
 	beginTag           = "-----BEGIN CERTIFICATE-----\n"
 	endTag             = "\n-----END CERTIFICATE-----"
+	requeueAfterNS     = 1800000000000
 )
 
 var log = logf.Log.WithName("controller")
@@ -671,7 +672,8 @@ func (r *ReconcileMetadata) Reconcile(request reconcile.Request) (reconcile.Resu
 		)
 	}
 
-	return reconcile.Result{}, nil
+	log.Info(fmt.Sprintf("Instance reconciliation complete - requeuing in %d seconds", requeueAfterNS/1000000000))
+	return reconcile.Result{RequeueAfter: requeueAfterNS}, nil
 }
 
 func generateTruststore(cert []byte, alias, storePass string) ([]byte, error) {


### PR DESCRIPTION
This is already running in the sandbox with the refresh time set to 30 seconds (to make it easy to check). Use `gds sandbox k -n sandbox-metadata-controller logs v1-vmc-0 controller -f` to check the logs yourself. Alternatively, see the selected log extracts below:
```
{"level":"info", "ts":" 2019-08-21T15:01:06 ", "logger":"controller", "msg":"Beginning Reconcile for metadata", "namespace":"sandbox-proxy-node-dev", "name":"test-integration-connector-metadata}
{"level":"info", "ts":" 2019-08-21T15:01:06 ", "logger":"controller", "msg":"Hash of metadata values", "namespace":"sandbox-proxy-node-dev", "hashValue":"14965631923677869862", "name":"test-integration-connector-metadata}
{"level":"info", "ts":" 2019-08-21T15:01:06 ", "logger":"controller", "msg":"Checking if metadata secret should be regenerated", "namespace":"sandbox-proxy-node-dev", "name":"test-integration-connector-metadata}
{"level":"info", "ts":" 2019-08-21T15:01:06 ", "logger":"controller", "msg":"Regenerating secret":" false - validUntilTimeStamp "2019-09-19 10:58:01 +0000 UTC" not before regeneratePastThisDate "2019-08-21 15:01:06.533951313 +0000 UTC m=+360.726384689"}
{"level":"info", "ts":" 2019-08-21T15:01:06 ", "logger":"controller", "msg":"Instance reconciliation complete - requeuing in 30 seconds}
```
```
{"level":"info", "ts":" 2019-08-21T15:01:36 ", "logger":"controller", "msg":"Beginning Reconcile for metadata", "namespace":"sandbox-proxy-node-dev", "name":"test-integration-connector-metadata}
{"level":"info", "ts":" 2019-08-21T15:01:36 ", "logger":"controller", "msg":"Hash of metadata values", "namespace":"sandbox-proxy-node-dev", "hashValue":"14965631923677869862", "name":"test-integration-connector-metadata}
{"level":"info", "ts":" 2019-08-21T15:01:36 ", "logger":"controller", "msg":"Checking if metadata secret should be regenerated", "namespace":"sandbox-proxy-node-dev", "name":"test-integration-connector-metadata}
{"level":"info", "ts":" 2019-08-21T15:01:36 ", "logger":"controller", "msg":"Regenerating secret":" false - validUntilTimeStamp "2019-09-19 10:58:01 +0000 UTC" not before regeneratePastThisDate "2019-08-21 15:01:36.535255796 +0000 UTC m=+390.727689189"}
{"level":"info", "ts":" 2019-08-21T15:01:36 ", "logger":"controller", "msg":"Instance reconciliation complete - requeuing in 30 seconds}
```

### EID-1624 Schedule metadata refresh  …
We want to schedule metadata to be periodically refreshed. We can return
a `reconcileResult` with a `RequeuAfter` value when we successfully
created or updated metadata.

### EID-1624 Add logging  …
This should help us see what's happening in the VMC logs