### PR TITLE
EID-1617 - Allow metadata to remount

### DIFF
--- a/pkg/controller/metadata/metadata_controller.go
+++ b/pkg/controller/metadata/metadata_controller.go
@@ -364,7 +364,7 @@ func ShouldRegenerate(secretsObj *corev1.Secret, hashOfRequestSpec string, insta
 
 	// If the rest of the config has changed and the hash has changed, regenerate regardless.
 	if secretsObj.ObjectMeta.Annotations[versionAnnotation] != hashOfRequestSpec {
-		log.Info("Regenerating secret - hash's don't match")
+		log.Info("Regenerating secret - hashes don't match")
 		return true
 	}
 
@@ -555,13 +555,8 @@ func (r *ReconcileMetadata) Reconcile(request reconcile.Request) (reconcile.Resu
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "data",
-									MountPath: fmt.Sprintf("/usr/share/nginx/html/%s", getPublishingPath(instance)),
-									SubPath:   metadataXMLKey,
-								},
-								{
-									Name:      "data",
-									MountPath: fmt.Sprintf("/usr/share/nginx/html/%s", getMetadataCACertsPublishingPath(instance)),
-									SubPath:   metadataCACertsKey,
+									MountPath: "/usr/share/nginx/html",
+									ReadOnly:  true,
 								},
 							},
 						},
@@ -572,6 +567,16 @@ func (r *ReconcileMetadata) Reconcile(request reconcile.Request) (reconcile.Resu
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName: instance.Name,
+									Items: []corev1.KeyToPath{
+										{
+											Key:  metadataXMLKey,
+											Path: getPublishingPath(instance),
+										},
+										{
+											Key:  metadataCACertsKey,
+											Path: getMetadataCACertsPublishingPath(instance),
+										},
+									},
 								},
 							},
 						},


### PR DESCRIPTION
This is rebased on top of [PR#44](https://github.com/alphagov/verify-metadata-controller/pull/44) and so only the last commit should be reviewed.
I've run this in the sandbox and seen the updated metadata secret get remounted in the connector deployment.

I've also now observed the published proxy-node metadata updating in response to it's metadata secret being updated.

### EID-1617 Allow connector-node metadata to remount  …
The way we were mounting the metadata secret volume into the container
was preventing the volume from being automatically remounted if it
changed. Something to do with how `SubPath` used symlinks.

[The docs](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets) suggest doing it this way, and this is how we already do it [for the
proxy-node](https://github.com/alphagov/verify-proxy-node/blob/master/chart/templates/stub-connector-deployment.yaml#L35)

Also adds `ReadOnly` because we shouldn't be changing these from within
the container.