### PR TITLE
add the blessed talksToHsm label to the VMC pod

### DIFF
--- a/chart/templates/vmc-statefulset.yaml
+++ b/chart/templates/vmc-statefulset.yaml
@@ -18,6 +18,7 @@ spec:
   template:
     metadata:
       labels:
+        talksToHsm: "true"
         app.kubernetes.io/name: vmc
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:


### PR DESCRIPTION
## What

adds the `talksToHsm: true` label to the vmc pod

## why

a NetworkPolicy restricts access to cloudhsm network unless it has the
blessed talksToHsm:true label on the Pod.
