### PR TITLE
BAU: Improve logging

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,24 +10,6 @@
   version = "v0.35.1"
 
 [[projects]]
-  digest = "1:6c4532e144405fe72f05ff5531930b23dd86f7f68ef657f65a2d8be9bc692795"
-  name = "github.com/alphagov/verify-metadata-controller"
-  packages = [
-    "pkg/apis",
-    "pkg/apis/verify/v1beta1",
-    "pkg/controller",
-    "pkg/controller/certificaterequest",
-    "pkg/controller/metadata",
-    "pkg/hsm",
-    "pkg/hsm/awscloudhsm",
-    "pkg/hsm/hsmfakes",
-    "pkg/webhook",
-  ]
-  pruneopts = "T"
-  revision = "6142ec6dc83d196a91b7379c21dff15516d260f1"
-  version = "v1.174"
-
-[[projects]]
   digest = "1:464aef731a5f82ded547c62e249a2e9ec59fbbc9ddab53cda7b9857852630a61"
   name = "github.com/appscode/jsonpatch"
   packages = ["."]
@@ -961,15 +943,6 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/alphagov/verify-metadata-controller/pkg/apis",
-    "github.com/alphagov/verify-metadata-controller/pkg/apis/verify/v1beta1",
-    "github.com/alphagov/verify-metadata-controller/pkg/controller",
-    "github.com/alphagov/verify-metadata-controller/pkg/controller/certificaterequest",
-    "github.com/alphagov/verify-metadata-controller/pkg/controller/metadata",
-    "github.com/alphagov/verify-metadata-controller/pkg/hsm",
-    "github.com/alphagov/verify-metadata-controller/pkg/hsm/awscloudhsm",
-    "github.com/alphagov/verify-metadata-controller/pkg/hsm/hsmfakes",
-    "github.com/alphagov/verify-metadata-controller/pkg/webhook",
     "github.com/emicklei/go-restful",
     "github.com/mitchellh/hashstructure",
     "github.com/onsi/ginkgo",

--- a/pkg/hsm/awscloudhsm/cloudhsm.go
+++ b/pkg/hsm/awscloudhsm/cloudhsm.go
@@ -184,6 +184,8 @@ func (c *Client) GenerateAndSignMetadata(request hsm.GenerateMetadataRequest) (s
 
 	log.Info("mdgen-done",
 		"metadata", string(metadata),
+		"metadataSigningKeyLabel", request.MetadataSigningKeyLabel,
+		"samlSigningKeyLabel", request.SamlSigningKeyLabel,
 	)
 	return metadata, nil
 }


### PR DESCRIPTION
**Improve and unify logging**
Added standard methods for logging to ensure request name and namespace are always logged. This allows to easily filter the logs for a specific metadata request, for instance:
```
gds sandbox k -n sandbox-metadata-controller logs v1-vmc-0 -c controller --follow | jq -c '.ts |= todate | select(.name=="test-proxy-node-metadata") | del(.logger, .name, .namespace)'
```
**Remove VMC from imported packages**
The VMC project should be placed in a specific location to maintain the Go project structure. Then Go doesn't need to clone VMC from GitHub.
Set your GOPATH to a dir and them place the VMC project in
`$GOPATH/src/github.com/alphagov/verify-metadata-controller`
