### PR TITLE
BAU Sign metadata with RSASSA-PSS

### DIFF
--- a/cloudhsmtool/src/main/java/uk/gov/ida/cloudhsmtool/CreateChainedCertificate.java
+++ b/cloudhsmtool/src/main/java/uk/gov/ida/cloudhsmtool/CreateChainedCertificate.java
@@ -77,7 +77,7 @@ public class CreateChainedCertificate extends CreateSelfSignedCertificate implem
             certBuilder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.digitalSignature));
         }
 
-        ContentSigner signer = new CaviumRSAContentSigner((PrivateKey) parentKey, SIGNING_ALGO_SHA256_RSA);
+        ContentSigner signer = new CaviumRSAContentSigner((PrivateKey) parentKey, ALGO_ID_SIGNATURE_RSA_SHA256_MGF1);
 
         return buildX509Certificate(certBuilder, signer);
     }

--- a/cloudhsmtool/src/main/java/uk/gov/ida/cloudhsmtool/CreateSelfSignedCertificate.java
+++ b/cloudhsmtool/src/main/java/uk/gov/ida/cloudhsmtool/CreateSelfSignedCertificate.java
@@ -99,7 +99,7 @@ public class CreateSelfSignedCertificate extends HSMCli implements Callable<Void
         certBuilder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.keyCertSign));
         certBuilder.addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
 
-        ContentSigner signer = new CaviumRSAContentSigner(keyPair.getPrivate(), SIGNING_ALGO_SHA256_RSA);
+        ContentSigner signer = new CaviumRSAContentSigner(keyPair.getPrivate(), ALGO_ID_SIGNATURE_RSA_SHA256_MGF1);
 
         return buildX509Certificate(certBuilder, signer);
     }

--- a/cloudhsmtool/src/main/java/uk/gov/ida/cloudhsmtool/GenRSA.java
+++ b/cloudhsmtool/src/main/java/uk/gov/ida/cloudhsmtool/GenRSA.java
@@ -12,7 +12,6 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
-import java.security.PublicKey;
 import java.util.concurrent.Callable;
 
 @CommandLine.Command(

--- a/cloudhsmtool/src/main/java/uk/gov/ida/cloudhsmtool/HSMCli.java
+++ b/cloudhsmtool/src/main/java/uk/gov/ida/cloudhsmtool/HSMCli.java
@@ -19,7 +19,7 @@ public  class HSMCli {
     public static final BigInteger RSA_PUBLIC_EXPONENT = BigInteger.valueOf(65537);
     public static final String SIGNING_ALGO_SHA256_RSA = "SHA256withRSA";
     public static final String LABEL_PUBLIC_SUFFIX = ":public";
-    public static final int DEFAULT_KEY_SIZE = 2048;
+    public static final int DEFAULT_KEY_SIZE = 3072;
     public static final String PROVIDER_NAME_CAVIUM = "Cavium";
 
     @CommandLine.Parameters(arity = "1", description = "keystore alias")

--- a/cloudhsmtool/src/main/java/uk/gov/ida/cloudhsmtool/HSMCli.java
+++ b/cloudhsmtool/src/main/java/uk/gov/ida/cloudhsmtool/HSMCli.java
@@ -12,12 +12,11 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
 
 public  class HSMCli {
 
     public static final BigInteger RSA_PUBLIC_EXPONENT = BigInteger.valueOf(65537);
-    public static final String SIGNING_ALGO_SHA256_RSA = "SHA256withRSA";
+    public static final String ALGO_ID_SIGNATURE_RSA_SHA256_MGF1 = "SHA256WITHRSAANDMGF1";
     public static final String LABEL_PUBLIC_SUFFIX = ":public";
     public static final int DEFAULT_KEY_SIZE = 3072;
     public static final String PROVIDER_NAME_CAVIUM = "Cavium";

--- a/mdgen/docker/Dockerfile
+++ b/mdgen/docker/Dockerfile
@@ -24,8 +24,6 @@ RUN wget https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/Xenial/clou
     wget http://de.archive.ubuntu.com/ubuntu/pool/main/libe/libedit/libedit2_3.1-20150325-1ubuntu2_amd64.deb
 RUN dpkg -i *.deb
 
-RUN /opt/cloudhsm/bin/configure -a $(dig +short a88bb4c07943b11e9bbf30ae9bf7a1ac-aa921f50a00f6c2a.elb.eu-west-2.amazonaws.com)
-
 RUN rbenv install 2.4.1
 
 COPY ./sandbox-customerCA.crt /opt/cloudhsm/etc/customerCA.crt

--- a/mdgen/docker/integration_tests/features/feature/launch.feature
+++ b/mdgen/docker/integration_tests/features/feature/launch.feature
@@ -27,4 +27,4 @@ Feature: The java app
     And the file contains the supplied saml encryption certificate: "<encryption_cert>"
     Examples:
       | node_type | algorithm | signing_cert                        | encryption_cert                        |
-      | connector | RSA       | test-supplied-saml-signing-cert.pem | test-supplied-saml-encryption-cert.pem |
+      | connector | RSAPSS    | test-supplied-saml-signing-cert.pem | test-supplied-saml-encryption-cert.pem |

--- a/mdgen/docker/integration_tests/features/step_definitions/launch_steps.rb
+++ b/mdgen/docker/integration_tests/features/step_definitions/launch_steps.rb
@@ -64,7 +64,7 @@ end
 
 private
 def run_app(node_type, algorithm)
-  `java -classpath '/opt/cloudhsm/java/*:mdgen/lib/*' uk.gov.ida.mdgen.MetadataGenerator #{node_type} ../test/#{node_type}.yml ../test/test-metadata-signing-cert.pem --hsm-saml-signing-cert-file ../test/test-hsm-generated-saml-signing-cert.pem --hsm-saml-signing-key-label this-is-a-cloudhsmtool-thing --hsm-metadata-signing-key-label this-is-a-cloudhsmtool-thing --output ./metadata.xml --validityTimestamp "Mon, 02 Jan 2006 15:04:05 +0000" 2>&1`
+  `java -classpath '/opt/cloudhsm/java/*:mdgen/lib/*' uk.gov.ida.mdgen.MetadataGenerator #{node_type} ../test/#{node_type}.yml ../test/test-metadata-signing-cert.pem --hsm-saml-signing-cert-file ../test/test-hsm-generated-saml-signing-cert.pem --algorithm #{algorithm} --hsm-saml-signing-key-label this-is-a-cloudhsmtool-thing --hsm-metadata-signing-key-label this-is-a-cloudhsmtool-thing --output ./metadata.xml --validityTimestamp "Mon, 02 Jan 2006 15:04:05 +0000" 2>&1`
 end
 
 def run_app_with_certs(node_type, algorithm, signing_cert, encryption_cert)

--- a/mdgen/docker/start.bash
+++ b/mdgen/docker/start.bash
@@ -1,6 +1,8 @@
 #!/bin/bash
 export LD_LIBRARY_PATH=/opt/cloudhsm/lib
 export HSM_PARTITION=PARTITION_1
+hsm_ip_address=$(dig +short a88bb4c07943b11e9bbf30ae9bf7a1ac-aa921f50a00f6c2a.elb.eu-west-2.amazonaws.com | head -n 1)
+/opt/cloudhsm/bin/configure -a "${hsm_ip_address}"
 /opt/cloudhsm/bin/cloudhsm_client /opt/cloudhsm/etc/cloudhsm_client.cfg > cloudhsm.log 2>&1 &
 cd /integration_tests
 gem install bundler

--- a/mdgen/src/main/java/uk/gov/ida/mdgen/MetadataGenerator.java
+++ b/mdgen/src/main/java/uk/gov/ida/mdgen/MetadataGenerator.java
@@ -70,7 +70,6 @@ public class MetadataGenerator implements Callable<Void> {
     enum NodeType {connector, proxy}
 
     enum SigningAlgoType {
-        rsa(XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256),
         rsapss(XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256_MGF1),
         ecdsa(XMLSignature.ALGO_ID_SIGNATURE_ECDSA_SHA256);
 
@@ -97,7 +96,7 @@ public class MetadataGenerator implements Callable<Void> {
     private File outputFile;
 
     @CommandLine.Option(names = "--algorithm", description = "Signing algorithm")
-    private SigningAlgoType signingAlgo = SigningAlgoType.rsa;
+    private SigningAlgoType signingAlgo = SigningAlgoType.rsapss;
 
     @CommandLine.Option(names = "--hsm-saml-signing-key-label", description = "HSM Signing key label (required for self-signed SAML Signing cert from HSM)")
     private String hsmSamlSigningKeyLabel;

--- a/pkg/hsm/awscloudhsm/cloudhsm.go
+++ b/pkg/hsm/awscloudhsm/cloudhsm.go
@@ -157,7 +157,7 @@ func (c *Client) GenerateAndSignMetadata(request hsm.GenerateMetadataRequest) (s
 		specFileName,
 		tmpMetadataSigningCertPath,
 		"--output", tmpMetadataOutputPath,
-		"--algorithm", "rsa",
+		"--algorithm", "rsapss",
 		"--hsm-metadata-signing-key-label", request.MetadataSigningKeyLabel,
 		"--hsm-saml-signing-key-label", request.SamlSigningKeyLabel,
 		samlSigningOption, tmpSAMLSigningCertPath,


### PR DESCRIPTION
I'm not going to merge this until it can tested in the sandbox (currently broken).

Interestingly, to comply with eIDAS spec we will need to rotate our private signing key as well as the certs in our certificate chain, as they've been signed with a 2048 bit key, rather than at least a 3073 bit key, as well as signed with the wrong algorithm.

When this is merged, it *won't* change our current private keys automatically - we would need to delete them first. It _will_ start signing our metadata with the correct algorithm though.

One option is to change our key length and cert chain when we move countries over to the multi-tenancy proxy-node.

### BAU Move hsm ip resolution out of Dockerfile
The HSM ip address used by the cloudhsm daemon was being baked in to the
Docker image. We've found that the call to dig is now returning more
than one IP address. This change selects the first IP returned whenever
the image is started which should hopefully make it more resilient.

### BAU Update default signing algorith in mdgen
The eIDAS spec mandates that you should use RSAPSS instead of RSS.

### BAU Usa rsapss algorithm to sign metadata
The eIDAS spec mandates we should use RSSPSS instead of RSS

### BAU Increase key size to 3072 bits
The eIDAS spec states that saml assertions, messages and metadata need
to be signed with a key with a minimal length of 3072 bits.

This is going to require us to rotate our private key, which is going to
be interesting...

### BAU Create certs with RSA_SHA256_MGF1
eIDAS spec states that X.509 certs within the certificate chain must
use RSASSA-PSS with a minimal key length of 3072 bits and a minimal hash
length of 256 bits.

The value of `ALGO_ID_SIGNATURE_RSA_SHA256_MGF1` being used is taken from
the bouncycastle class, `DefaultSignatureAlgorithmIdentifierFinder`,
which is called by our `CaviumRSAContentSigner` class.