### PR TITLE
Use the internal service for the Harbor API

### DIFF
--- a/ci/sandbox/deploy-pipeline.yaml
+++ b/ci/sandbox/deploy-pipeline.yaml
@@ -24,7 +24,6 @@ spec:
       username: ((harbor.harbor_username))
       password: ((harbor.harbor_password))
       harbor:
-        url: ((harbor.harbor_url))
         prevent_vul: "false"
       notary:
         url: ((harbor.notary_url))
@@ -54,8 +53,8 @@ spec:
       type: docker-image
       privileged: true
       source:
-        repository: govsvc/gsp-harbor-docker-image-resource
-        tag: 0.0.1553882420
+        repository: ((concourse.harbor-resource-image))
+        tag: ((concourse.harbor-resource-tag))
 
     resources:
 

--- a/ci/sandbox/release-pipeline.yaml
+++ b/ci/sandbox/release-pipeline.yaml
@@ -24,7 +24,6 @@ spec:
       username: ((harbor.harbor_username))
       password: ((harbor.harbor_password))
       harbor:
-        url: ((harbor.harbor_url))
         prevent_vul: "false"
       notary:
         url: ((harbor.notary_url))
@@ -59,8 +58,8 @@ spec:
       type: docker-image
       privileged: true
       source:
-        repository: govsvc/gsp-harbor-docker-image-resource
-        tag: 0.0.1553882420
+        repository: ((concourse.harbor-resource-image))
+        tag: ((concourse.harbor-resource-tag))
 
     resources:
 

--- a/ci/verify/release-pipeline.yaml
+++ b/ci/verify/release-pipeline.yaml
@@ -24,7 +24,6 @@ spec:
       username: ((harbor.harbor_username))
       password: ((harbor.harbor_password))
       harbor:
-        url: ((harbor.harbor_url))
         prevent_vul: "false"
       notary:
         url: ((harbor.notary_url))
@@ -59,8 +58,8 @@ spec:
       type: docker-image
       privileged: true
       source:
-        repository: govsvc/gsp-harbor-docker-image-resource
-        tag: 0.0.1553882420
+        repository: ((concourse.harbor-resource-image))
+        tag: ((concourse.harbor-resource-tag))
 
     resources:
 


### PR DESCRIPTION
We (autom8) want to be able to block access from the public internet to
the Harbor API. Previously we had done this by implementing a IP
safelist. Given some changes we're expecting to make to Istio we will be
unable to see the original IP of the user at the point that our current
safelist performs its checks.

We have decided to block API access entirely (except from within the
cluster).

Our `concourse-harbor-resource` now defaults to using the internal
service to talk to the Harbor API so all we need to do is remove the
explicit setting of `harbor.url`.