### PR TITLE
[DO NOT MERGE]BAU - Bump cloudhsm tools to 3.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager github.com/alph
 FROM amazonlinux:2.0.20190212
 
 # Install AWS CloudHSM client and libs
-ENV CLOUDHSM_CLIENT_VERSION=2.0.3-3.el7
+ENV CLOUDHSM_CLIENT_VERSION=3.0.0-2.el7
 RUN yum install -y wget tar gzip openssl \
  && wget --progress=bar:force https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-${CLOUDHSM_CLIENT_VERSION}.x86_64.rpm \
  && yum install -y ./cloudhsm-client-*.rpm \

--- a/cloudhsmtool/build.gradle
+++ b/cloudhsmtool/build.gradle
@@ -26,6 +26,6 @@ dependencies {
     'org.apache.logging.log4j:log4j-core:2.8'
 
     if (project.hasProperty('cloudhsm')) {
-      implementation name: 'cloudhsm-2.0.3'
+      implementation name: 'cloudhsm-3.0.0'
     }
 }

--- a/mdgen/build.gradle
+++ b/mdgen/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     'org.yaml:snakeyaml:1.24-SNAPSHOT'
 
     if (project.hasProperty('cloudhsm')) {
-      implementation name: 'cloudhsm-2.0.3'
+      implementation name: 'cloudhsm-3.0.0'
       implementation name: 'log4j-api-2.8'
       implementation name: 'log4j-core-2.8'
     }


### PR DESCRIPTION
This has been deployed and ~~works~~ doesn't work in the sandbox

There is a new major version of the cloudhsm client software

I was looking into this to see if they had released a fix to the issue
we're experiencing with the hsm retaining temporary keys. It looks like
this version does not fix that issue, but it's still probably a good
idea to upgrade.

I've applied this change to the sandbox without any issues.