### PR TITLE
EID-1941: Upgrade cloudhsm client to v3.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager github.com/alph
 FROM amazonlinux:2.0.20190212
 
 # Install AWS CloudHSM client and libs
-ENV CLOUDHSM_CLIENT_VERSION=2.0.3-3.el7
+ENV CLOUDHSM_CLIENT_VERSION=3.0.0-2.el7
 RUN yum install -y wget tar gzip openssl \
  && wget --progress=bar:force https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-${CLOUDHSM_CLIENT_VERSION}.x86_64.rpm \
  && yum install -y ./cloudhsm-client-*.rpm \

--- a/cloudhsmtool/build.gradle
+++ b/cloudhsmtool/build.gradle
@@ -26,6 +26,6 @@ dependencies {
     'org.apache.logging.log4j:log4j-core:2.8'
 
     if (project.hasProperty('cloudhsm')) {
-      implementation name: 'cloudhsm-2.0.3'
+      implementation name: 'cloudhsm-3.0.0'
     }
 }

--- a/cloudhsmtool/src/main/java/uk/gov/ida/cloudhsmtool/CloudHSMTool.java
+++ b/cloudhsmtool/src/main/java/uk/gov/ida/cloudhsmtool/CloudHSMTool.java
@@ -3,20 +3,8 @@ package uk.gov.ida.cloudhsmtool;
 import com.cavium.provider.CaviumProvider;
 import picocli.CommandLine;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.OutputStream;
-import java.io.StringWriter;
-import java.security.KeyStore;
-import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.Security;
-import java.security.cert.X509Certificate;
-import java.security.interfaces.ECPublicKey;
-import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.Callable;
 
 @CommandLine.Command(subcommands = {
@@ -34,7 +22,7 @@ public class CloudHSMTool implements Callable<Void> {
 	}
 
 	@Override
-	public Void call() throws Exception {
+	public Void call() {
 		System.err.println("Please invoke a subcommand");
 		CommandLine cmd = new CommandLine(new CloudHSMTool());
 		cmd.usage(System.err);

--- a/cloudhsmtool/src/main/java/uk/gov/ida/cloudhsmtool/CreateSelfSignedCertificate.java
+++ b/cloudhsmtool/src/main/java/uk/gov/ida/cloudhsmtool/CreateSelfSignedCertificate.java
@@ -67,7 +67,7 @@ public class CreateSelfSignedCertificate extends HSMCli implements Callable<Void
         if (!(privateKey instanceof PrivateKey)) {
             throw new Exception("failed to fetch PrivateKey for " + hsmKeyLabel);
         }
-        Key publicKey = ks.getKey(hsmKeyLabel + LABEL_PUBLIC_SUFFIX, null);
+        com.cavium.key.CaviumKey publicKey = com.cavium.cfm2.Util.findFirstCaviumKey(hsmKeyLabel + LABEL_PUBLIC_SUFFIX);
         if (!(publicKey instanceof PublicKey)) {
             throw new Exception("failed to fetch PublicKey for " + hsmKeyLabel + LABEL_PUBLIC_SUFFIX);
         }

--- a/cloudhsmtool/src/main/java/uk/gov/ida/cloudhsmtool/GenRSA.java
+++ b/cloudhsmtool/src/main/java/uk/gov/ida/cloudhsmtool/GenRSA.java
@@ -12,7 +12,6 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
-import java.security.PublicKey;
 import java.util.concurrent.Callable;
 
 @CommandLine.Command(
@@ -36,7 +35,7 @@ public class GenRSA extends HSMCli implements Callable<Void> {
         if (!(privateKey instanceof PrivateKey)) {
             throw new Exception("failed to fetch PrivateKey for "+hsmKeyLabel);
         }
-        Key publicKey = ks.getKey(hsmKeyLabel+":public", null);
+        com.cavium.key.CaviumKey publicKey = com.cavium.cfm2.Util.findFirstCaviumKey(hsmKeyLabel + LABEL_PUBLIC_SUFFIX);
         if (!(publicKey instanceof PublicKey)) {
             throw new Exception("failed to fetch PublicKey for "+hsmKeyLabel+"public");
         }

--- a/mdgen/build.gradle
+++ b/mdgen/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     'org.yaml:snakeyaml:1.24-SNAPSHOT'
 
     if (project.hasProperty('cloudhsm')) {
-      implementation name: 'cloudhsm-2.0.3'
+      implementation name: 'cloudhsm-3.0.0'
       implementation name: 'log4j-api-2.8'
       implementation name: 'log4j-core-2.8'
     }


### PR DESCRIPTION
There are currently no real tests* for the changes being made here other than to test them out in the sandbox. These two commits are currently pushed to the sandbox branch of the VMC and I have observed both `cloudhsmtool` and `mdgen` working as intented.

If you want to check them for yourself you can do so by:

Jumping on to the VMC application and running the cloudhsmtool directly - this will create a new RSA keypair in the sandbox HSM.
```
$ gds sandbox k -n sandbox-metadata-controller exec -it v1-vmc-0 /bin/bash
$ cloudhsmtool/build/install/cloudhsmtool/bin/cloudhsmtool genrsa <a key alias you made up> 
```

Regenerating some metadata succesfully (already on the VMC box):
    Tail the VMC logs in one terminal window
```
gds sandbox k -n sandbox-metadata-controller logs v1-vmc-0 controller --follow | jq .
```
In another terminal fetch the yaml for a current metadata resource, edit the spec, and then reapply it to the cluster
```
$ gds sandbox k -n sandbox-proxy-node-dev get metadata test-proxy-node-metadata -o yaml > md.yaml
# manually edit md.yaml spec - change the validity days for example
$ gds sandbox k -n sandbox-proxy-node-dev apply -f md.yaml
```

Observe the metadata being regenerated successfully in the logs you're following.

\* There are some tests for mdgen which are currently broken due to not being able to remotely access the sandbox HSM. RE are working on a fix which should allow the tests to work again.

### EID-1941: Upgrade cloudhsm tooling to v3.0.0
We need to update the algorithm we use to sign certificates and
metadata. We have two tools that perform these tasks for us -
`cloudhsmtool` and `mdgen`. Both use HSM to sign.

The java library provided by the AWS cloudhsm tooling includes the
Cavium security provider. Version 2 of Cavium does not appear to support
the RSAPSS algorithms we're required to sign with. Version 3 does.

### EID-1941: Get public keys from HSM with Cavium util
The new version of the Cavium library has an interesting new "feature".
The `getKey` method on the CaviumKeyStore now explicitly returns null if
the key being got is a PublicKey. This broke the `cloudhsmtool`.

Fortunately after decompiling and inspecting the library it turns out
that the Cavium libary has a Util class with a `findFirstCaviumKey`
method which will fetch the public keys for us.