### PR TITLE
sandbox ci: Use git resource instead of github

### DIFF
--- a/ci/sandbox/release-pipeline.yaml
+++ b/ci/sandbox/release-pipeline.yaml
@@ -55,7 +55,7 @@ spec:
     resources:
 
     - name: src
-      type: github
+      type: git
       icon: github-circle
       source:
         <<: *github_source


### PR DESCRIPTION
So we can push to sandbox branches without a PR.