### PR TITLE
Update the sandbox CloudHSM ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Note: Access to the Sandbox environments CloudHSM is only possible from a GDS IP
 1. Configure CloudHSM Client:
     ```
     apt-get install dnsutils -y
-    /opt/cloudhsm/bin/configure -a $(dig +short a88bb4c07943b11e9bbf30ae9bf7a1ac-aa921f50a00f6c2a.elb.eu-west-2.amazonaws.com)
+    /opt/cloudhsm/bin/configure -a $(dig +short afe8ce8bf61fb11eaa69a0af1fbe14c4-afb9ba656e22f14e.elb.eu-west-2.amazonaws.com | head -n 1)
     ```
 1. Test the connection by listing users:
     ```

--- a/cloudhsmtool/Dockerfile
+++ b/cloudhsmtool/Dockerfile
@@ -24,7 +24,7 @@ RUN wget https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/Xenial/clou
     wget http://de.archive.ubuntu.com/ubuntu/pool/main/libe/libedit/libedit2_3.1-20150325-1ubuntu2_amd64.deb && \
     dpkg -i *.deb
 
-RUN /opt/cloudhsm/bin/configure -a $(dig +short a88bb4c07943b11e9bbf30ae9bf7a1ac-aa921f50a00f6c2a.elb.eu-west-2.amazonaws.com)
+RUN /opt/cloudhsm/bin/configure -a $(dig +short afe8ce8bf61fb11eaa69a0af1fbe14c4-afb9ba656e22f14e.elb.eu-west-2.amazonaws.com | head -n 1)
 
 COPY ./sandbox-customerCA.crt /opt/cloudhsm/etc/customerCA.crt
 COPY ./src /cloudhsmtool/src

--- a/mdgen/docker/Dockerfile
+++ b/mdgen/docker/Dockerfile
@@ -24,7 +24,7 @@ RUN wget https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/Xenial/clou
     wget http://de.archive.ubuntu.com/ubuntu/pool/main/libe/libedit/libedit2_3.1-20150325-1ubuntu2_amd64.deb
 RUN dpkg -i *.deb
 
-RUN /opt/cloudhsm/bin/configure -a $(dig +short a88bb4c07943b11e9bbf30ae9bf7a1ac-aa921f50a00f6c2a.elb.eu-west-2.amazonaws.com)
+RUN /opt/cloudhsm/bin/configure -a $(dig +short afe8ce8bf61fb11eaa69a0af1fbe14c4-afb9ba656e22f14e.elb.eu-west-2.amazonaws.com | head -n 1)
 
 RUN rbenv install 2.4.1
 


### PR DESCRIPTION
We had to rebuild the sandbox CloudHSM ingress so we've got a new LB and
therefore a new domain for it.