### PR TITLE
ZEN-3950985 Proxy Node metadata spaces

### DIFF
--- a/mdgen/src/main/resources/proxy_template.xml.mustache
+++ b/mdgen/src/main/resources/proxy_template.xml.mustache
@@ -2,7 +2,7 @@
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:alg="urn:oasis:names:tc:SAML:metadata:algsupport" xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute" ID="_9ebc8854ec7f701da9749e87a801e5f2" entityID="{{entity_id}}" validUntil="2015-05-24T19:30:26.624Z">
   <md:Extensions>
     <mdattr:EntityAttributes>
-      <saml2:Attribute Name="urn:oasis:names:tc:SAML:attribute:assurance-certification " NameFormat="urn:oasis:names:tc:saml2:2.0:attrname-format:uri">
+      <saml2:Attribute Name="urn:oasis:names:tc:SAML:attribute:assurance-certification" NameFormat="urn:oasis:names:tc:saml2:2.0:attrname-format:uri">
         <saml2:AttributeValue>http://eidas.europa.eu/LoA/substantial</saml2:AttributeValue>
       </saml2:Attribute>
     </mdattr:EntityAttributes>
@@ -15,9 +15,9 @@
     <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="{{post_url}}"/>
     <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="{{redirect_url}}"/>
     <saml2:Attribute FriendlyName="PersonIdentifier" Name="http://eidas.europa.eu/attributes/naturalperson/PersonIdentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"></saml2:Attribute>
-    <saml2:Attribute FriendlyName="FamilyName" Name=" http://eidas.europa.eu/attributes/naturalperson/CurrentFamilyName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"></saml2:Attribute>
-    <saml2:Attribute FriendlyName="FirstName" Name=" http://eidas.europa.eu/attributes/naturalperson/CurrentGivenName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"></saml2:Attribute>
-    <saml2:Attribute FriendlyName="DateOfBirth" Name=" http://eidas.europa.eu/attributes/naturalperson/DateOfBirth" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"></saml2:Attribute>
+    <saml2:Attribute FriendlyName="FamilyName" Name="http://eidas.europa.eu/attributes/naturalperson/CurrentFamilyName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"></saml2:Attribute>
+    <saml2:Attribute FriendlyName="FirstName" Name="http://eidas.europa.eu/attributes/naturalperson/CurrentGivenName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"></saml2:Attribute>
+    <saml2:Attribute FriendlyName="DateOfBirth" Name="http://eidas.europa.eu/attributes/naturalperson/DateOfBirth" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"></saml2:Attribute>
   </md:IDPSSODescriptor>
   <md:Organization>
     <md:OrganizationName xml:lang="en">Government Digital Service</md:OrganizationName>


### PR DESCRIPTION
Spaces in the VMC `proxy_template.xml.mustache` are reported  to be causing Netherlands to have issues parsing our Proxy Node response, see https://govuk.zendesk.com/agent/tickets/3950985.
Remove these spaces.