### PR TITLE
BAU Upgrade VMC mdgen snakeyaml

### DIFF
--- a/mdgen/build.gradle
+++ b/mdgen/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     'org.slf4j:slf4j-simple:1.7.25',
     'se.litsec.opensaml:opensaml3-ext:1.2.2',
     'com.github.spullara.mustache.java:compiler:0.9.6',
-    'org.yaml:snakeyaml:1.24-SNAPSHOT'
+    'org.yaml:snakeyaml:1.26'
 
     if (project.hasProperty('cloudhsm')) {
       implementation name: 'cloudhsm-3.0.0'


### PR DESCRIPTION
The [VMC build pipeline](https://ci.london.verify.govsvc.uk/teams/metadata-controller/pipelines/release/jobs/build-vmc) is failing as this snapshot dependency doesn't exist - bump the version to the same as the cloudhsmtool 