### PR TITLE
⌫ EID-1943 Remove refs to settings.gradle from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,12 +40,10 @@ COPY settings.gradle ./settings.gradle
 COPY gradle ./gradle
 
 COPY mdgen/build.gradle                 ./mdgen/build.gradle
-COPY mdgen/settings.gradle              ./mdgen/settings.gradle
 COPY mdgen/src                          ./mdgen/src
 COPY mdgen/test                         ./mdgen/test
 
 COPY cloudhsmtool/build.gradle         ./cloudhsmtool/build.gradle
-COPY cloudhsmtool/settings.gradle      ./cloudhsmtool/settings.gradle
 COPY cloudhsmtool/src                  ./cloudhsmtool/src
 
 RUN ./gradlew --console rich --parallel -Pcloudhsm --no-daemon


### PR DESCRIPTION
During PR review we removed settings.gradle from sub-projects.
This was never reflected in Dockerfile and the [build breaks](https://ci.london.verify.govsvc.uk/teams/metadata-controller/pipelines/release/jobs/build-vmc/builds/9) building the docker image.

Tested locally by `docker build`ing the Dockerfile minus the `golang` bits.