### PR TITLE
BAU Restore RSA-SHA256 Metadata Signing Algo for RSA keys

### DIFF
--- a/mdgen/src/main/java/uk/gov/ida/mdgen/MetadataGenerator.java
+++ b/mdgen/src/main/java/uk/gov/ida/mdgen/MetadataGenerator.java
@@ -168,7 +168,7 @@ public class MetadataGenerator implements Callable<Void> {
     private void setupSigningAlgo() {
         if (metadataSigningCredential.getPublicKey() instanceof RSAPublicKey) {
             Security.addProvider(new BouncyCastleProvider());
-            signingAlgo = SigningAlgoType.rsapss;
+            signingAlgo = SigningAlgoType.rsa;
 
         } else if (metadataSigningCredential.getPublicKey() instanceof ECPublicKey) {
             signingAlgo = SigningAlgoType.ecdsa;

--- a/mdgen/src/test/java/uk/gov/ida/mdgen/MetadataGeneratorTest.java
+++ b/mdgen/src/test/java/uk/gov/ida/mdgen/MetadataGeneratorTest.java
@@ -44,7 +44,7 @@ public class MetadataGeneratorTest extends MdgenTestUtils {
         );
 
         EntityDescriptor entityDescriptor = (EntityDescriptor) XMLObjectSupport.unmarshallFromInputStream(getParserPool(), getFileFromPath(metadata));
-        assertThat(entityDescriptor.getSignature().getSignatureAlgorithm()).isEqualTo(XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA384_MGF1);
+        assertThat(entityDescriptor.getSignature().getSignatureAlgorithm()).isEqualTo(XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256);
     }
 
     @Test


### PR DESCRIPTION
We started using the `http://www.w3.org/2007/05/xmldsig-more#sha384-rsa-MGF1` siging algo for existing RSA keys in HSM, and this is resulting in Connector Nodes being unable to accept our Proxy Node metadata.

Use the BAU metadata signing algo of `http://www.w3.org/2001/04/xmldsig-more#rsa-sha25` for existing BAU RSA keys.

Multi-country Proxy Node metadata uses EC keys and will not be affected.