### PR TITLE
BAU Remove SpType of 'public'

### DIFF
--- a/mdgen/src/main/resources/connector_template.xml.mustache
+++ b/mdgen/src/main/resources/connector_template.xml.mustache
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:eidas="http://eidas.europa.eu/saml-extensions" xmlns:alg="urn:oasis:names:tc:SAML:metadata:algsupport" ID="_9ebc8854ec7f701da9749e87a801e5f2" entityID="{{entity_id}}" validUntil="2015-05-24T19:30:26.624Z">
   <md:Extensions>
-    <eidas:SPType>public</eidas:SPType>
     <alg:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
     <alg:SigningMethod MinKeySize="256" Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256"/>
     <alg:SigningMethod MinKeySize="2048" MaxKeySize="4096" Algorithm="http://www.w3.org/2007/05/xmldsig-more#sha256-rsa-MGF1"/>


### PR DESCRIPTION
We send this SPType in our eidas SAML Request and the spec forbids it being present in both metadata and request.

Needed to progress on a DE middleware upgrade spike