### PR TITLE
EID-1960: Production request cert

### DIFF
--- a/chart/templates/cert-request-production-a1.yaml
+++ b/chart/templates/cert-request-production-a1.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: verify.gov.uk/v1beta1
+kind: CertificateRequest
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: eidas-pki
+  name: verify-root-ca-production-a1
+  namespace: {{ .Release.Namespace }}
+spec:
+  countryCode: GB
+  commonName: GOV.UK Verify Root CA A1
+  expiryMonths: 120
+  organization: Cabinet Office
+  organizationUnit: GDS
+  location: London
+  CACert: true


### PR DESCRIPTION
Made a copy of cert-request-test-a1.yaml but replaced test with production in the filename, and removed “test” from the yaml. This will create a new root CA cert, that has been created by an EC key