### PR TITLE
Use dockerhubpull secrets to access DockerHub

### DIFF
--- a/chart/templates/vmc-statefulset.yaml
+++ b/chart/templates/vmc-statefulset.yaml
@@ -22,6 +22,8 @@ spec:
         app.kubernetes.io/name: vmc
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      imagePullSecrets:
+      - name: dockerhubpull
       containers:
       - name: controller
         image: "{{ .Values.vmc.image.repository }}:{{ .Values.vmc.image.tag }}"

--- a/ci/sandbox/release-pipeline.yaml
+++ b/ci/sandbox/release-pipeline.yaml
@@ -24,6 +24,8 @@ spec:
       source:
         repository: ((concourse.task-toolbox-image))
         tag: ((concourse.task-toolbox-tag))
+        username: ((dockerhubpull-concourse.username))
+        password: ((dockerhubpull-concourse.password))
 
     image_tag: &image_tag
       tag_file: src/.git/short_ref
@@ -37,6 +39,8 @@ spec:
         type: registry-image
         source:
           repository: vito/oci-build-task
+          username: ((dockerhubpull-concourse.username))
+          password: ((dockerhubpull-concourse.password))
         version:
           digest: sha256:cfb2983956145f54a4996c2aff5fc598856c8722922a6e73f9ebfa3d9b3f9813
       caches:
@@ -51,6 +55,8 @@ spec:
       source:
         repository: ((concourse.github-resource-image))
         tag: ((concourse.github-resource-tag))
+        username: ((dockerhubpull-concourse.username))
+        password: ((dockerhubpull-concourse.password))
 
     resources:
 
@@ -273,6 +279,8 @@ spec:
             type: registry-image
             source:
               repository: vito/oci-build-task
+              username: ((dockerhubpull-concourse.username))
+              password: ((dockerhubpull-concourse.password))
             version:
               digest: sha256:cfb2983956145f54a4996c2aff5fc598856c8722922a6e73f9ebfa3d9b3f9813
           caches:

--- a/ci/verify/deploy-pipeline.yaml
+++ b/ci/verify/deploy-pipeline.yaml
@@ -24,6 +24,8 @@ spec:
       source:
         repository: ((concourse.task-toolbox-image))
         tag: ((concourse.task-toolbox-tag))
+        username: ((dockerhubpull-concourse.username))
+        password: ((dockerhubpull-concourse.password))
 
     resource_types:
 
@@ -32,6 +34,8 @@ spec:
       source:
         repository: ((concourse.github-resource-image))
         tag: ((concourse.github-resource-tag))
+        username: ((dockerhubpull-concourse.username))
+        password: ((dockerhubpull-concourse.password))
 
     resources:
 

--- a/ci/verify/release-pipeline.yaml
+++ b/ci/verify/release-pipeline.yaml
@@ -22,6 +22,8 @@ spec:
       source:
         repository: ((concourse.task-toolbox-image))
         tag: ((concourse.task-toolbox-tag))
+        username: ((dockerhubpull-concourse.username))
+        password: ((dockerhubpull-concourse.password))
 
     resource_types:
 
@@ -30,6 +32,8 @@ spec:
       source:
         repository: ((concourse.github-resource-image))
         tag: ((concourse.github-resource-tag))
+        username: ((dockerhubpull-concourse.username))
+        password: ((dockerhubpull-concourse.password))
 
     resources:
 
@@ -89,6 +93,8 @@ spec:
             type: registry-image
             source:
               repository: vito/oci-build-task
+              username: ((dockerhubpull-concourse.username))
+              password: ((dockerhubpull-concourse.password))
             version:
               digest: sha256:cfb2983956145f54a4996c2aff5fc598856c8722922a6e73f9ebfa3d9b3f9813
           params:
@@ -119,6 +125,8 @@ spec:
             type: registry-image
             source:
               repository: vito/oci-build-task
+              username: ((dockerhubpull-concourse.username))
+              password: ((dockerhubpull-concourse.password))
             version:
               digest: sha256:cfb2983956145f54a4996c2aff5fc598856c8722922a6e73f9ebfa3d9b3f9813
           params:


### PR DESCRIPTION
Add this even to pods that don't explicitly reference DockerHub because they
will most likely get containers that do injected by Istio anyway.

This secret is provided by GSP. Do not merge until GSP v1.1.686 has
successfully rolled out to verify.